### PR TITLE
onShutdown method should be called only after server.close.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ const debug = require('debug')('http-graceful-shutdown');
 let isShuttingDown = false;
 let connections = {};
 let connectionCounter = 0;
+let failed = false;
 
 /**
  * Gracefully shuts down `server` when the process receives
@@ -116,12 +117,15 @@ function GracefulShutdown(server, opts) {
     }
 
     const finalHandler = () => {
-      process.exit(0);
+      process.exit(failed ? 1 : 0);
     };
 
-    const errorHandler = (err) => {
-      console.log(err);
-    };
+    const exitHandler = promise => promise
+      .catch((err) => {
+        console.log(err);
+        failed = true;
+      });
+
 
     if (!isShuttingDown) {
       isShuttingDown = true;
@@ -135,19 +139,12 @@ function GracefulShutdown(server, opts) {
         }, options.timeout).unref();
       }
 
-      // your personal cleanup things can be placed in this callback function
-      if (options.onShutdown && isFunction(options.onShutdown)) {
-        cleanupHttp().then(() => {
-          return options.onShutdown();
-        }).then(() => {
-          finalHandler();
-        }).catch(errorHandler);
-
-      } else {
-        cleanupHttp().then(() => {
-          finalHandler();
-        }).catch(errorHandler);
-      }
+      exitHandler(cleanupHttp()).then(() => {
+        if (options.onShutdown && isFunction(options.onShutdown)) {
+          return exitHandler(options.onShutdown());
+        }
+        return;
+      }).then(finalHandler);
     }
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,7 @@ function GracefulShutdown(server, opts) {
 
     function cleanupHttp() {
 
-      return Promise((resolve, reject) => {
+      return new Promise((resolve, reject) => {
         Object.keys(connections).forEach(function (key) {
           counter++;
           destroy(connections[key]);

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,18 +89,22 @@ function GracefulShutdown(server, opts) {
 
     function cleanupHttp() {
 
-      Object.keys(connections).forEach(function (key) {
-        counter++;
-        destroy(connections[key]);
+      return Promise((resolve, reject) => {
+        Object.keys(connections).forEach(function (key) {
+          counter++;
+          destroy(connections[key]);
+        });
+
+        debug('Connections destroyed : ' + counter);
+        debug('Connection Counter    : ' + connectionCounter);
+
+        // normal shutdown
+        server.close(function (err) {
+          if(err) return reject(err);
+          resolve();
+        });
       });
 
-      debug('Connections destroyed : ' + counter);
-      debug('Connection Counter    : ' + connectionCounter);
-
-      // normal shutdown
-      server.close(function () {
-        process.exit(0);
-      });
     }
 
     debug('shutdown signal - ' + sig);
@@ -110,6 +114,14 @@ function GracefulShutdown(server, opts) {
       debug('DEV-Mode - imediate forceful shutdown');
       return process.exit(0);
     }
+
+    const finalHandler = () => {
+      process.exit(0);
+    };
+
+    const errorHandler = (err) => {
+      console.log(err);
+    };
 
     if (!isShuttingDown) {
       isShuttingDown = true;
@@ -125,11 +137,16 @@ function GracefulShutdown(server, opts) {
 
       // your personal cleanup things can be placed in this callback function
       if (options.onShutdown && isFunction(options.onShutdown)) {
-        options.onShutdown().then(() => {
-          cleanupHttp();
-        });
+        cleanupHttp().then(() => {
+          return options.onShutdown();
+        }).then(() => {
+          finalHandler();
+        }).catch(errorHandler);
+
       } else {
-        cleanupHttp();
+        cleanupHttp().then(() => {
+          finalHandler();
+        }).catch(errorHandler);
       }
     }
   }


### PR DESCRIPTION
## Pull Request

Fixes #

#### Changes proposed:

* [ ] Fix
* [ ] Add
* [ ] Remove
* [ ] Update

#### Description (what is this PR about)
onShutdown mehtod was called before `server.close`. If there was an existing connection using database, that would be interrupted. So to fix this the onShutdown method is only called after server.close. Cleanup happens after server stops listening for connections.
