### PR TITLE
Fix: different kinds of function shall be supported, such as AsyncFunction.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,8 +53,8 @@ function GracefulShutdown(server, opts) {
   }
 
   function isFunction(functionToCheck) {
-    let getType = {};
-    return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
+    let getType = Object.prototype.toString.call(functionToCheck);
+    return /^\[object\s([a-zA-Z]+)?Function\]$/.test(getType);
   }
 
   server.on('request', function (req, res) {


### PR DESCRIPTION

## Pull Request

Fixes #

#### Changes proposed:

* Just modify the `isFunction` function, to support other kinds of function besides the normal function with type `[object Function]`. Especially, an **async function**'s type is `[object AsyncFunction]`.

#### Description

Enable other function types for callbacks (namely `finally` and `onShutdown` so far) in the `options`.

