### PR TITLE
Fix forceExit default value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,7 @@ function GracefulShutdown(server, opts) {
     debug('received shut down signal', signal);
     shutdown(signal)
       .then(() => {
-        if (opts.forceExit) {
+        if (options.forceExit) {
           process.exit(failed ? 1 : 0);
         }
       })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-graceful-shutdown",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
## Pull Request

Fixes #

#### Changes proposed:

This is a fix

#### Description (what is this PR about)

When custom options that do not set `forceExit` field is passed, it will not be set to the default value.