### PR TITLE
Server closing promise will be resolved if it is returned in shutdown promise resolving

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -272,7 +272,7 @@ function GracefulShutdown(server, opts) {
       .preShutdown(sig)
       .then(() => {
         isShuttingDown = true;
-        cleanupHttp();
+        return cleanupHttp();
       })
       .then(() => {
         const pollIterations = options.timeout

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-graceful-shutdown",
-  "version": "3.1.13",
+  "version": "3.1.14",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
## Pull Request

Fixes #

#### Changes proposed:

This is a fix for Server closing promise to be resolved when there are no requests to be handled by the server
Just added return 

#### Description (what is this PR about)
when there are requests to be handled by the server, this module works fine.

but when there are no requests to handle by the server, server closing is not resolving
and also server close listener is not working 
`server.on('close', () => console.log('HTTP server closed'))`

I added return only.
