### PR TITLE
Capture socket in response finish callback closure directly rather than relying on request object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,14 +151,15 @@ function GracefulShutdown(server, opts) {
   // set up server/process events
   // ----------------------------------
   server.on('request', function (req, res) {
-    req.socket._isIdle = false;
+    const socket = req.socket
+    socket._isIdle = false;
     if (isShuttingDown && !res.headersSent) {
       res.setHeader('connection', 'close');
     }
 
     res.on('finish', function () {
-      req.socket._isIdle = true;
-      destroy(req.socket);
+      socket._isIdle = true;
+      destroy(socket);
     });
   });
 


### PR DESCRIPTION
In certain circumstances, a request object's socket will be disassociated or destroyed prior to the response's finish event firing. In this case, `req.socket` will be `null`. This change ensures that the `.on('finish')` closure will reference the socket directly rather than referencing it through the request.

```
uncaughtException: TypeError: Cannot set properties of null (setting '_isIdle')
    at ServerResponse.<anonymous> (/Users/admin/Projects/home-portal/node_modules/http-graceful-shutdown/lib/index.js:160:26)
    at ServerResponse.emit (node:events:531:35)
    at onFinish (node:_http_outgoing:1031:10)
    at callback (node:internal/streams/writable:764:21)
    at afterWrite (node:internal/streams/writable:708:5)
    at afterWriteTick (node:internal/streams/writable:694:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:81:21)
```